### PR TITLE
Isaac continuing sabouteur

### DIFF
--- a/goaldiggersrc/blockhandling/detachBloke.mod2g
+++ b/goaldiggersrc/blockhandling/detachBloke.mod2g
@@ -6,10 +6,12 @@ module detachBloke {
 	% ToDo: Reset belief if attached for a long time (with counter).
 	
 	% detach a bloke during dragger routine
+	
+	%if bel(customRole(customRoleSaboteur)) then allother.send(mensaje("Trying to detach")).
 	if bel(customRole(customRoleSaboteur), whitelistedTeam(OurTeam)), 
 	   percept(attached(X,Y), thing(X,Y, entity, OtherTeam), OurTeam \= OtherTeam), not(bel(X =:= 0, Y =:=0)),
 	   bel(directionToCoordinate(Dir, X, Y)) 
-	    then detach(Dir).	
+	    then detach(Dir).
 	
 	% detach a bloke if directly attached to yourself
 	if percept(attached(0,0), thing(X, Y, entity, _), abs(X) =< 1, abs(Y) =< 1), 

--- a/goaldiggersrc/blockhandling/detachBloke.mod2g
+++ b/goaldiggersrc/blockhandling/detachBloke.mod2g
@@ -5,6 +5,12 @@ module detachBloke {
 
 	% ToDo: Reset belief if attached for a long time (with counter).
 	
+	% detach a bloke during dragger routine
+	if bel(customRole(customRoleSaboteur), whitelistedTeam(OurTeam)), 
+	   percept(attached(X,Y), thing(X,Y, entity, OtherTeam), OurTeam \= OtherTeam), not(bel(X =:= 0, Y =:=0)),
+	   bel(directionToCoordinate(Dir, X, Y)) 
+	    then detach(Dir).	
+	
 	% detach a bloke if directly attached to yourself
 	if percept(attached(0,0), thing(X, Y, entity, _), abs(X) =< 1, abs(Y) =< 1), 
 	   bel(directionToCoordinate(Dir, X, Y)) 

--- a/goaldiggersrc/eventsubmodules/debugtools/logMiniPercept.mod2g
+++ b/goaldiggersrc/eventsubmodules/debugtools/logMiniPercept.mod2g
@@ -64,6 +64,8 @@ module logMiniPercept {
 			then print(Step|Role+"Agent: "+Result+LastAction| Para| Param2| Param3).
 
 		if bel(customRole(customRoleSaboteur)) then print("This is a saboteur.").
+		if bel(dragging) then print("The saboteur is dragging someone.").
+		if bel(dragCounter(X)) then print("The dragging counter is "+X).
 
 		% some extra extra custom percept logging because conditional can be false, others for formatting
 	    if bel(agentAt(X, Y, _), targetMd(A, B, Target))

--- a/goaldiggersrc/eventsubmodules/debugtools/logMiniPercept.mod2g
+++ b/goaldiggersrc/eventsubmodules/debugtools/logMiniPercept.mod2g
@@ -63,10 +63,15 @@ module logMiniPercept {
 		           lastActionParams([Para, Param2, Param3]))
 			then print(Step|Role+"Agent: "+Result+LastAction| Para| Param2| Param3).
 
-		if bel(customRole(customRoleSaboteur)) then print("This is a saboteur.").
-		if bel(dragging) then print("The saboteur is dragging someone.").
-		if bel(dragCounter(X)) then print("The dragging counter is "+X).
-
+		if bel(customRole(customRoleSaboteur)) then {
+			if true then print("This is a saboteur.").
+			if bel(dragging) then print("The saboteur is dragging someone.").
+			if bel(dragCounter(X)) then print("The dragging counter is "+X).
+			if bel(emptyGoalZoneCounter(_,_,_)) then print("Empty goal zones:").
+			if not(bel(emptyGoalZoneCounter(_,_,_))) then print("No empty goal zones found.").
+			forall bel(emptyGoalZoneCounter(A,B,C)) do print(A+" "+B+" "+C).
+		}
+		
 		% some extra extra custom percept logging because conditional can be false, others for formatting
 	    if bel(agentAt(X, Y, _), targetMd(A, B, Target))
 	    	then print("This step AgentAt: "| X| Y+"TargetMD: "| A| B| Target).

--- a/goaldiggersrc/eventsubmodules/manageManhattanTarget.mod2g
+++ b/goaldiggersrc/eventsubmodules/manageManhattanTarget.mod2g
@@ -37,49 +37,79 @@ module manageManhattanTarget {
 	}
 
 
-	% when role test worker set goalzone as target
-	if bel(customRole(customRoleSaboteur)), bel(searchInGoalzone), 
-	   not(bel(emptyGoalZoneCounter(_,_,Count), waitingTimeEmptyGoalZone(Time), Count > Time)) then {
-		   		if true then updateGoalzoneDistance.
-		   		if bel(targetClosestGoalZone(X, Y, _)) then {
+	if bel(customRole(customRoleSaboteur)) then {
+	
+		% when role saboteur with no one attached set other agent as target next to a goal zone
+		if percept(goalZone(_,_)), bel(attachedBlokes(Count), Count == 0, whitelistedTeam(MyTeam)), 
+	     percept(thing(X, Y, entity, OtherTeam), MyTeam \= OtherTeam), not(percept(attached(X,Y))),
+		 bel(agentAt(X2, Y2, _), localize(X, Y, X2, Y2, X3, Y3), abs(X) + abs(Y) >= 2) then {
+	       	if bel(targetMd(X4, Y4, Target)) then delete(targetMd(X4, Y4, Target)). 
+			if true then insert(targetMd(X3, Y3, agent)).	
+			if not(bel(executeManhattan)) then insert(executeManhattan).
+	     }
+
+		% when role saboteur with someone attached set other agent as target anywhere
+		if bel(attachedBlokes(Count), Count > 0, whitelistedTeam(MyTeam)), 
+	     percept(thing(X, Y, entity, OtherTeam), MyTeam \= OtherTeam), not(percept(attached(X,Y))),
+		 bel(agentAt(X2, Y2, _), localize(X, Y, X2, Y2, X3, Y3), abs(X) + abs(Y) >= 2) then {
+	       	if bel(targetMd(X4, Y4, Target)) then delete(targetMd(X4, Y4, Target)). 
+			if true then insert(targetMd(X3, Y3, agent)).	
+			if not(bel(executeManhattan)) then insert(executeManhattan).
+	     }
+	
+		% when role saboteur with dragging routine set other agent as target anywhere
+		if bel(dragger, whitelistedTeam(MyTeam)), 
+	     percept(thing(X, Y, entity, OtherTeam), MyTeam \= OtherTeam), not(percept(attached(X,Y))),
+		 bel(agentAt(X2, Y2, _), localize(X, Y, X2, Y2, X3, Y3), abs(X) + abs(Y) >= 2) then {
+	       	if bel(targetMd(X4, Y4, Target)) then delete(targetMd(X4, Y4, Target)). 
+			if true then insert(targetMd(X3, Y3, agent)).	
+			if not(bel(executeManhattan)) then insert(executeManhattan).
+	     }
+	
+		% when role saboteur set goalzone as target
+		if bel(searchInGoalzone), 
+		   not(bel(emptyGoalZoneCounter(_,_,Count), waitingTimeEmptyGoalZone(Time), Count > Time)) then {
+			   		if true then updateGoalzoneDistance.
+			   		if bel(targetClosestGoalZone(X, Y, _)) then {
+						if bel(targetMd(X4, Y4, Target)) then delete(targetMd(X4, Y4, Target)). 
+						if true then insert(targetMd(X, Y, goalzone)).	
+						if not(bel(executeManhattan)) then insert(executeManhattan).
+					}
+		}
+	
+		% when role saboteur worker in empty goalZone set other goalzone as target
+		if bel(searchInGoalzone), 
+		   bel(emptyGoalZoneCounter(_,_,Count), waitingTimeEmptyGoalZone(Time), Count > Time)
+		   then {
+			   		if true then updateGoalzoneDistance.
+			   		
+			   		forall bel(mapGoalZone(A,B,C)) do insert(tempMapGoalZone(A,B,C)).
+			   		forall bel(tempMapGoalZone(X,Y,D)) do {
+			   		   if bel(emptyGoalZoneCounter(X1, Y1, Count1), calculateXYMd(X1,Y1,X,Y,Md), 
+			   		          minimumDistanceEmptyGoalZone(Dist), Md < Dist, Count1 > Time)
+			   		   then delete(tempMapGoalZone(X, Y, D)).
+			   		} % end deletion of tempMapGoalZone
+			   		
+			   		if bel(tempMapGoalZone(A, B, C)) then {
+			   		    if bel(targetMd(X4, Y4, Target)) then delete(targetMd(X4, Y4, Target)). 
+						if true then insert(targetMd(A, B, goalzone)).	
+						if not(bel(executeManhattan)) then insert(executeManhattan).
+						forall bel(tempMapGoalZone(X, Y, D)) do delete(tempMapGoalZone(X, Y, D)).
+			   		}		   		
+		}
+				
+	
+		% when role saboteur and without bloke set dispenser as target
+		if bel(customRole(customRoleSaboteur), haveBlokeAttached(false,_), searchInDispenser,
+			   mapDispenser(X,Y,dispenser,BlockType,_,_)), percept(task(_, _, _,[req(_,_,BlockType)])), 
+			   not(bel(emptyDispenserCounter(X, Y, Count), Count > 20)) then {		
 					if bel(targetMd(X4, Y4, Target)) then delete(targetMd(X4, Y4, Target)). 
-					if true then insert(targetMd(X, Y, goalzone)).	
+					if true then insert(targetMd(X, Y, dispenser)).	
 					if not(bel(executeManhattan)) then insert(executeManhattan).
-				}
-	}
+		}
 
-	% when role saboteur worker in empty goalZone set other goalzone as target
-	if bel(customRole(customRoleSaboteur)), bel(searchInGoalzone), 
-	   bel(emptyGoalZoneCounter(_,_,Count), waitingTimeEmptyGoalZone(Time), Count > Time)
-	   then {
-		   		if true then updateGoalzoneDistance.
-		   		
-		   		forall bel(mapGoalZone(A,B,C)) do insert(tempMapGoalZone(A,B,C)).
-		   		forall bel(tempMapGoalZone(X,Y,D)) do {
-		   		   if bel(emptyGoalZoneCounter(X1, Y1, Count1), calculateXYMd(X1,Y1,X,Y,Md), 
-		   		          minimumDistanceEmptyGoalZone(Dist), Md < Dist, Count1 > Time)
-		   		   then delete(tempMapGoalZone(X, Y, D)).
-		   		} % end deletion of tempMapGoalZone
-		   		
-		   		if bel(tempMapGoalZone(A, B, C)) then {
-		   		    if bel(targetMd(X4, Y4, Target)) then delete(targetMd(X4, Y4, Target)). 
-					if true then insert(targetMd(A, B, goalzone)).	
-					if not(bel(executeManhattan)) then insert(executeManhattan).
-					forall bel(tempMapGoalZone(X, Y, D)) do delete(tempMapGoalZone(X, Y, D)).
-		   		}		   		
 	}
 	
-	
-
-	% when role test worker and without bloke set dispenser as target
-	if bel(customRole(customRoleSaboteur), haveBlokeAttached(false,_), searchInDispenser,
-		   mapDispenser(X,Y,dispenser,BlockType,_,_)), percept(task(_, _, _,[req(_,_,BlockType)])), 
-		   not(bel(emptyDispenserCounter(X, Y, Count), Count > 20)) then {		
-				if bel(targetMd(X4, Y4, Target)) then delete(targetMd(X4, Y4, Target)). 
-				if true then insert(targetMd(X, Y, dispenser)).	
-				if not(bel(executeManhattan)) then insert(executeManhattan).
-	}
-
 	% With block and as submittingAgent update goalzone target MD
 	if bel(haveBlockAttached(true, _), step(SimStep), currentChosenTask(_, TaskStep, _, _, _, _, OneOrTwoTask, _), 
 	       TaskStep >= SimStep, targetMd(X, Y, Target), targetClosestGoalZone(A, B, MdAlt), MdAlt < 1234567),

--- a/goaldiggersrc/eventsubmodules/manageManhattanTarget.mod2g
+++ b/goaldiggersrc/eventsubmodules/manageManhattanTarget.mod2g
@@ -71,6 +71,19 @@ module manageManhattanTarget {
 			   		}		   		
 		}
 				
+		% when role saboteur in still not declared empty goal zone, select distant point of that goal zone
+		if percept(goalZone(0,0)), bel(whitelistedTeam(MyTeam)), 
+		   not(percept(thing(X1,Y1,entity,OtherTeam), goalZone(X1,Y1), OtherTeam \= MyTeam, (X1 \= 0; Y1 \= 0))), 
+		   not(percept(attached(X1, Y1))), bel(agentAt(X4, Y4, _)), 
+		   not(bel(minimumDistanceEmptyGoalZone(Distance), waitingTimeEmptyGoalZone(Time), emptyGoalZoneCounter(X5, Y5, C), 
+		   calculateXYMd(X5, Y5, X4, Y4, Md), Md < Distance, C > Time)) then {
+		     	     
+		     if percept(goalZone(X6, Y6)), bel(calculateXYMd(X6, Y6, 0, 0, 5), localize(X6, Y6, X4, Y4, X7, Y7)),
+		        bel(targetMd(X0, Y0, Target))
+		     	then delete(targetMd(X0, Y0, Target)) + insert(targetMd(X7, Y7, goalZone)).
+		     if not(bel(executeManhattan)) then insert(executeManhattan).	        
+		}
+
 	
 		% when role saboteur and without bloke set dispenser as target
 		if bel(customRole(customRoleSaboteur), haveBlokeAttached(false,_), searchInDispenser,

--- a/goaldiggersrc/eventsubmodules/manageManhattanTarget.mod2g
+++ b/goaldiggersrc/eventsubmodules/manageManhattanTarget.mod2g
@@ -37,34 +37,7 @@ module manageManhattanTarget {
 	}
 
 
-	if bel(customRole(customRoleSaboteur)) then {
-	
-		% when role saboteur with no one attached set other agent as target next to a goal zone
-		if percept(goalZone(_,_)), bel(attachedBlokes(Count), Count == 0, whitelistedTeam(MyTeam)), 
-	     percept(thing(X, Y, entity, OtherTeam), MyTeam \= OtherTeam), not(percept(attached(X,Y))),
-		 bel(agentAt(X2, Y2, _), localize(X, Y, X2, Y2, X3, Y3), abs(X) + abs(Y) >= 2) then {
-	       	if bel(targetMd(X4, Y4, Target)) then delete(targetMd(X4, Y4, Target)). 
-			if true then insert(targetMd(X3, Y3, agent)).	
-			if not(bel(executeManhattan)) then insert(executeManhattan).
-	     }
-
-		% when role saboteur with someone attached set other agent as target anywhere
-		if bel(attachedBlokes(Count), Count > 0, whitelistedTeam(MyTeam)), 
-	     percept(thing(X, Y, entity, OtherTeam), MyTeam \= OtherTeam), not(percept(attached(X,Y))),
-		 bel(agentAt(X2, Y2, _), localize(X, Y, X2, Y2, X3, Y3), abs(X) + abs(Y) >= 2) then {
-	       	if bel(targetMd(X4, Y4, Target)) then delete(targetMd(X4, Y4, Target)). 
-			if true then insert(targetMd(X3, Y3, agent)).	
-			if not(bel(executeManhattan)) then insert(executeManhattan).
-	     }
-	
-		% when role saboteur with dragging routine set other agent as target anywhere
-		if bel(dragger, whitelistedTeam(MyTeam)), 
-	     percept(thing(X, Y, entity, OtherTeam), MyTeam \= OtherTeam), not(percept(attached(X,Y))),
-		 bel(agentAt(X2, Y2, _), localize(X, Y, X2, Y2, X3, Y3), abs(X) + abs(Y) >= 2) then {
-	       	if bel(targetMd(X4, Y4, Target)) then delete(targetMd(X4, Y4, Target)). 
-			if true then insert(targetMd(X3, Y3, agent)).	
-			if not(bel(executeManhattan)) then insert(executeManhattan).
-	     }
+	if bel(customRole(customRoleSaboteur)) then {		
 	
 		% when role saboteur set goalzone as target
 		if bel(searchInGoalzone), 
@@ -107,6 +80,33 @@ module manageManhattanTarget {
 					if true then insert(targetMd(X, Y, dispenser)).	
 					if not(bel(executeManhattan)) then insert(executeManhattan).
 		}
+
+		% when role saboteur with no one attached set other agent as target next to a goal zone
+		if percept(goalZone(_,_)), bel(attachedBlokes(Count), Count == 0, whitelistedTeam(MyTeam)), 
+	     percept(thing(X, Y, entity, OtherTeam), MyTeam \= OtherTeam), not(percept(attached(X,Y))),
+		 bel(agentAt(X2, Y2, _), localize(X, Y, X2, Y2, X3, Y3), abs(X) + abs(Y) >= 2) then {
+	       	if bel(targetMd(X4, Y4, Target)) then delete(targetMd(X4, Y4, Target)). 
+			if true then insert(targetMd(X3, Y3, agent)).	
+			if not(bel(executeManhattan)) then insert(executeManhattan).
+	     }
+
+		% when role saboteur with someone attached set other agent as target anywhere
+		if bel(attachedBlokes(Count), Count > 0, whitelistedTeam(MyTeam)), 
+	     percept(thing(X, Y, entity, OtherTeam), MyTeam \= OtherTeam), not(percept(attached(X,Y))),
+		 bel(agentAt(X2, Y2, _), localize(X, Y, X2, Y2, X3, Y3), abs(X) + abs(Y) >= 2) then {
+	       	if bel(targetMd(X4, Y4, Target)) then delete(targetMd(X4, Y4, Target)). 
+			if true then insert(targetMd(X3, Y3, agent)).	
+			if not(bel(executeManhattan)) then insert(executeManhattan).
+	     }
+	
+		% when role saboteur with dragging routine set other agent as target anywhere
+		if bel(dragger, whitelistedTeam(MyTeam)), 
+	     percept(thing(X, Y, entity, OtherTeam), MyTeam \= OtherTeam), not(percept(attached(X,Y))),
+		 bel(agentAt(X2, Y2, _), localize(X, Y, X2, Y2, X3, Y3), abs(X) + abs(Y) >= 2) then {
+	       	if bel(targetMd(X4, Y4, Target)) then delete(targetMd(X4, Y4, Target)). 
+			if true then insert(targetMd(X3, Y3, agent)).	
+			if not(bel(executeManhattan)) then insert(executeManhattan).
+	     }
 
 	}
 	

--- a/goaldiggersrc/eventsubmodules/syncLastActionResultDataIntoBelief.mod2g
+++ b/goaldiggersrc/eventsubmodules/syncLastActionResultDataIntoBelief.mod2g
@@ -84,7 +84,7 @@ module syncLastActionResultDataIntoBelief {
 
 		% succesfull detach action handling for saboteurs
 		if percept(lastAction(detach)),
-		   bel(attachedBlokes(BlokeNumber), NewBlokeNumber is BlokeNumber - 1)
+		   bel(attachedBlokes(BlokeNumber), BlokeNumber > 0, NewBlokeNumber is BlokeNumber - 1)
 		   then delete(attachedBlokes(BlokeNumber)) + insert(attachedBlokes(NewBlokeNumber)).
 
 		% rotate update attached coordinates

--- a/goaldiggersrc/eventsubmodules/syncLastActionResultDataIntoBelief.mod2g
+++ b/goaldiggersrc/eventsubmodules/syncLastActionResultDataIntoBelief.mod2g
@@ -83,9 +83,10 @@ module syncLastActionResultDataIntoBelief {
 		  }
 
 		% succesfull detach action handling for saboteurs
-		if percept(lastAction(detach)),
-		   bel(attachedBlokes(BlokeNumber), BlokeNumber > 0, NewBlokeNumber is BlokeNumber - 1)
-		   then delete(attachedBlokes(BlokeNumber)) + insert(attachedBlokes(NewBlokeNumber)).
+		if bel(customRole(customRoleSaboteur), dragger), percept(lastAction(detach), lastActionParams([Dir])),
+		   bel(attachedBlokes(BlokeNumber), BlokeNumber > 0, NewBlokeNumber is BlokeNumber - 1, haveBlokeAttached(true,Dir))
+		   then delete(attachedBlokes(BlokeNumber)) + insert(attachedBlokes(NewBlokeNumber))
+		        + delete(haveBlokeAttached(true,Dir)) + insert(haveBlokeAttached(false,Dir)).
 
 		% rotate update attached coordinates
 		if percept(lastAction(rotate), lastActionParams([Dir])),

--- a/goaldiggersrc/eventsubmodules/syncLastActionResultDataIntoBelief.mod2g
+++ b/goaldiggersrc/eventsubmodules/syncLastActionResultDataIntoBelief.mod2g
@@ -35,7 +35,8 @@ module syncLastActionResultDataIntoBelief {
 				    then delete(agentAt(X, Y, OldStep)) +
 				         insert(agentAt(X2, Y2, NewStep)).
 		    % update dragging counter if saboteur is dragging someone
-				if bel(dragging, dragCounter(Count), NewCount is Count + 1) 
+		    	if bel(dragCounter(Count)) then print("Drag Counter "+Count).
+				if bel(dragCounter(Count), NewCount is Count + 1)
 				   then delete(dragCounter(Count)) + insert(dragCounter(NewCount)) + print("Counter Updated").
 		}
 		% double move
@@ -75,6 +76,11 @@ module syncLastActionResultDataIntoBelief {
 		  	if not(bel(calculateNewDispenserMD))
 		  		then insert(calculateNewDispenserMD).
 		  }
+
+		% succesfull detach action handling for saboteurs
+		if percept(lastAction(detach)),
+		   bel(attachedBlokes(BlokeNumber), NewBlokeNumber is BlokeNumber - 1)
+		   then delete(attachedBlokes(BlokeNumber)) + insert(attachedBlokes(NewBlokeNumber)).
 
 		% rotate update attached coordinates
 		if percept(lastAction(rotate), lastActionParams([Dir])),

--- a/goaldiggersrc/eventsubmodules/syncLastActionResultDataIntoBelief.mod2g
+++ b/goaldiggersrc/eventsubmodules/syncLastActionResultDataIntoBelief.mod2g
@@ -34,6 +34,9 @@ module syncLastActionResultDataIntoBelief {
 				   bel(agentAt(X, Y, OldStep), OldStep < NewStep, transformXYD(D, X, Y, X2, Y2))
 				    then delete(agentAt(X, Y, OldStep)) +
 				         insert(agentAt(X2, Y2, NewStep)).
+		    % update dragging counter if saboteur is dragging someone
+				if bel(dragging, dragCounter(Count), NewCount is Count + 1) 
+				   then delete(dragCounter(Count)) + insert(dragCounter(NewCount)) + print("Counter Updated").
 		}
 		% double move
 		if percept(lastAction(move), lastActionParams([D, _])),

--- a/goaldiggersrc/eventsubmodules/syncLastActionResultDataIntoBelief.mod2g
+++ b/goaldiggersrc/eventsubmodules/syncLastActionResultDataIntoBelief.mod2g
@@ -19,6 +19,12 @@ module syncLastActionResultDataIntoBelief {
 					   bel(agentAt(X, Y, OldStep), OldStep < NewStep, transformXYD(D, X, Y, X2, Y2))
 					    then delete(agentAt(X, Y, OldStep)) +
 					         insert(agentAt(X2, Y2, NewStep)).
+			
+			% update dragging counter if saboteur is dragging someone
+			if percept(lastAction(move)), bel(dragCounter(Count), NewCount is Count + 1)
+				   then delete(dragCounter(Count)) + insert(dragCounter(NewCount)).
+
+
 			}
 	} % lastaction partial_success
 
@@ -35,9 +41,8 @@ module syncLastActionResultDataIntoBelief {
 				    then delete(agentAt(X, Y, OldStep)) +
 				         insert(agentAt(X2, Y2, NewStep)).
 		    % update dragging counter if saboteur is dragging someone
-		    	if bel(dragCounter(Count)) then print("Drag Counter "+Count).
 				if bel(dragCounter(Count), NewCount is Count + 1)
-				   then delete(dragCounter(Count)) + insert(dragCounter(NewCount)) + print("Counter Updated").
+				   then delete(dragCounter(Count)) + insert(dragCounter(NewCount)).
 		}
 		% double move
 		if percept(lastAction(move), lastActionParams([D, _])),

--- a/goaldiggersrc/eventsubmodules/syncPerceptDataIntoBelief.mod2g
+++ b/goaldiggersrc/eventsubmodules/syncPerceptDataIntoBelief.mod2g
@@ -94,6 +94,11 @@ module syncPerceptDataIntoBelief {
 	           	then delete(mapRoleZone(X, Y, Md)).
   	}
 	
+	% DELETE targetted blokes as Manhattan targets if they have moved away
+	if bel(customRole(customRoleSaboteur), executeManhattan, targetMd(X1,Y1, agent), agentAt(X2,Y2,_)), 
+	   not(percept(thing(X3,Y3,entity,_), localize(X3,Y3,X2,Y2,X1,Y1))) 
+       then  delete(targetMd(X1, Y1, agent)) + delete(executeManhattan). 
+	
 	% DELETE detached blokes
 	forall bel(haveBlokeAttached(true,Dir), directionToCoordinate(Dir, X, Y)) do {
 		if not(percept(attached(X, Y))), bel(attachedBlokes(Count), NewCount is Count - 1) 

--- a/goaldiggersrc/goaldiggerEvent.mod2g
+++ b/goaldiggersrc/goaldiggerEvent.mod2g
@@ -100,7 +100,7 @@ module goaldiggerEvent {
 	% set flag if test worker in empty goal zone
 	if bel(customRole(customRoleSaboteur)), percept(goalZone(0, 0)), bel(whitelistedTeam(MyTeam)), 
 	       not(percept(thing(X1, Y1, entity, OtherTeam), OtherTeam \= MyTeam, goalZone(X1, Y1))), 
-	       bel(agentAt(X2, Y2, _), minimumDistanceEmptyGoalZone(Distance))
+	       not(bel(X1 =:= 0, Y1 =:= 0)), bel(agentAt(X2, Y2, _), minimumDistanceEmptyGoalZone(Distance))
 	then {
 	   if bel(emptyGoalZoneCounter(A, B, C), NewCount is C +1, calculateXYMd(A, B, X2, Y2, Md), Md < Distance) then 
 	   delete(emptyGoalZoneCounter(A,B,C)) + insert(emptyGoalZoneCounter(A, B, NewCount)) + 

--- a/goaldiggersrc/goaldiggerEvent.mod2g
+++ b/goaldiggersrc/goaldiggerEvent.mod2g
@@ -32,17 +32,17 @@ use "./normhandling/analyzeNorms" as module.
  *
  */
 
-module goaldiggerEvent {  
-	
+module goaldiggerEvent {
+
 	% SUBMODULE reinitialize belief after simulation changes
 	if percept(step(0)),
-	   not(bel(thisIsTheFirstSim)) 
+	   not(bel(thisIsTheFirstSim))
 	   	then reinitBeliefOnSimChange.
-	   
+
 	% prevent first reinitBeliefOnSimChange activation
-	if bel(thisIsTheFirstSim) 
+	if bel(thisIsTheFirstSim)
 		then delete(thisIsTheFirstSim).
-	
+
 	% Logging made points by agents
 	if true
 		then logScoringBoard.
@@ -53,18 +53,18 @@ module goaldiggerEvent {
 	% SUBMODULE Store percept/message data in belief
 	if true then syncPerceptDataIntoBelief.
 	if true then syncMessageDataIntoBelief.
-	
+
 	% check attached block direction for block and if none found switch haveBlockAttached false
-    if bel(haveBlockAttached(true, DirBlock), directionToCoordinate(DirBlock, X, Y)), 
-       not(percept(attached(X, Y))) 
-        then delete(haveBlockAttached(true, DirBlock)) + 
+    if bel(haveBlockAttached(true, DirBlock), directionToCoordinate(DirBlock, X, Y)),
+       not(percept(attached(X, Y)))
+        then delete(haveBlockAttached(true, DirBlock)) +
              insert(haveBlockAttached(false, DirBlock)).
 
 	% SUBMODULES Choose RandomAgent for Explorer
-	if percept(step(SimStep), SimStep >= 6) 
+	if percept(step(SimStep), SimStep >= 6)
 		then updateAgentHierarchy.
 	if true then updateAssignExplorerRole.
-	
+
 	% SUBMODULE SimpleWorldcalculation
 	if true then handleMessageAgentOffset.
 	% add agentAtComplexWorld, mapDispenserComplexWorld, otherAgentAtComplexWorld (bel)
@@ -74,38 +74,38 @@ module goaldiggerEvent {
     % update current task for saboteur before messagePermaSendStatusToOthers
     if bel(customRole(customRoleSaboteur)),
        bel(currentChosenTask(V1, V2, V3, V4, V5, V6, V7, V8))
-        then delete(currentChosenTask(V1, V2, V3, V4, V5, V6, V7, V8)) + 
+        then delete(currentChosenTask(V1, V2, V3, V4, V5, V6, V7, V8)) +
              insert(currentChosenTask(taskSaboteur, -1, 100, 0, 0, bx, sabotaging, nameX)).
-	
+
 	% SUBMODULE Permanently send message to other agents with own status and on conditional greetings
-	if true then messagePermaSendStatusToOthers.	
+	if true then messagePermaSendStatusToOthers.
 
 	% SUBMODULE check messages about dispensers if none known
-	if true then handleMessageDispenser.	
-		
+	if true then handleMessageDispenser.
+
 	% SUBMODULE update dispenser map data as worker with no block and as worker with no active task
-	if bel(calculateNewDispenserMD, haveBlockAttached(false, _)), 
-	   percept(role(worker)) 
+	if bel(calculateNewDispenserMD, haveBlockAttached(false, _)),
+	   percept(role(worker))
 	   	then updateDispenserDistance.
 
 	% SUBMODULE help test worker tour around the goal zones
-	      
+
     % remove empty goal zone flag if agent seen in goal zone
-	if bel(customRole(customRoleSaboteur)), bel(whitelistedTeam(MyTeam)), percept(thing(X, Y, entity, OtherTeam), 
-	       OtherTeam \= MyTeam, goalZone(X, Y)) then {
+	if bel(customRole(customRoleSaboteur)), bel(whitelistedTeam(MyTeam)), percept(thing(X, Y, entity, OtherTeam),
+	       OtherTeam \= MyTeam, goalZone(X, Y), (X \= 0; Y \=0)) then {
 		forall bel(emptyGoalZoneCounter(A,B,C)) do delete(emptyGoalZoneCounter(A,B,C)).
 	}
-    
+
     %ToDo: Refactor this. WARNING: Changing A and B for some kind of X3, Y3 doesn't work. I don't know why.
 	% set flag if test worker in empty goal zone
-	if bel(customRole(customRoleSaboteur)), percept(goalZone(0, 0)), bel(whitelistedTeam(MyTeam)), 
-	       not(percept(thing(X1, Y1, entity, OtherTeam), OtherTeam \= MyTeam, goalZone(X1, Y1))), 
-	       not(bel(X1 =:= 0, Y1 =:= 0)), bel(agentAt(X2, Y2, _), minimumDistanceEmptyGoalZone(Distance))
+	if bel(customRole(customRoleSaboteur)), percept(goalZone(0, 0)), bel(whitelistedTeam(MyTeam)),
+	       not(percept(thing(X1, Y1, entity, OtherTeam), OtherTeam \= MyTeam, goalZone(X1, Y1), (X1 \= 0; Y1 \=0))),
+	       bel(agentAt(X2, Y2, _), minimumDistanceEmptyGoalZone(Distance))
 	then {
-	   if bel(emptyGoalZoneCounter(A, B, C), NewCount is C +1, calculateXYMd(A, B, X2, Y2, Md), Md < Distance) then 
-	   delete(emptyGoalZoneCounter(A,B,C)) + insert(emptyGoalZoneCounter(A, B, NewCount)) + 
+	   if bel(emptyGoalZoneCounter(A, B, C), NewCount is C +1, calculateXYMd(A, B, X2, Y2, Md), Md < Distance) then
+	   delete(emptyGoalZoneCounter(A,B,C)) + insert(emptyGoalZoneCounter(A, B, NewCount)) +
 	   allother.send(iBelieveGoalZoneCounter(A, B, NewCount, Md)).
-	   
+
 	   if not(bel(emptyGoalZoneCounter(X3, Y3, _), calculateXYMd(X3, Y3, X2, Y2, Md), Md < Distance))
 	   then insert(emptyGoalZoneCounter(X2, Y2, 1)) + allother.send(emptyGoalZoneCounter(X2, Y2, 1)).
 	}
@@ -115,30 +115,30 @@ module goaldiggerEvent {
 
 	% SUBMODULE managing messages concerning task coordination
 	if true then messageMultiTaskCoordination.
-	
+
 	% SUBMODULE check messages about role zones
 	%if percept(role(default)) then handleMessageRoleZone.
 	if true then handleMessageRoleZone.
 
     % SUBMODULE update rolezone map data
-    if percept(role(default)) 
+    if percept(role(default))
     	then updateRolezoneDistance.
 
 	% SUBMODULE check messages about goal zones
 	if true then handleMessageGoalZone.
-	    
+
 	% SUBMODULE delete goal zones if other agents have found that they don't exist anymore
 	if percept(step(SimStep), SimStep > 3333),
-	   (_).sent(messageDeletedGoalZone(_,_,_)) 
+	   (_).sent(messageDeletedGoalZone(_,_,_))
 	   	then handleMessageDeletedGoalZone.
-	   
+
 	% SUBMODULE update goalzone map data
-	if percept(step(SimStep),role(worker)), 
-	   bel(calculateNewGoalzoneMD, haveBlockAttached(true, _), 
-	       currentChosenTask(_, TaskStep, _, _, _, _,ClientServer,_), ClientServer \= supportingAgent, 
-	       TaskStep >= SimStep) 
+	if percept(step(SimStep),role(worker)),
+	   bel(calculateNewGoalzoneMD, haveBlockAttached(true, _),
+	       currentChosenTask(_, TaskStep, _, _, _, _,ClientServer,_), ClientServer \= supportingAgent,
+	       TaskStep >= SimStep)
 	    then updateGoalzoneDistance.
-	    
+
 	% SUBMODULE manhattan switch manipulation
 	if true then manageManhattanSwitchStatus.
 
@@ -146,7 +146,7 @@ module goaldiggerEvent {
 	if true then manageManhattanTarget.
 
     % check norms for possible damage to agents
-    if true 
+    if true
         then analyzeNorms.
 
 	/**
@@ -155,9 +155,9 @@ module goaldiggerEvent {
 	 */
 
 	% check old dispenser request and set switch to false
-	if percept(step(Step)), 
-	   bel(haveDispenserDelivery(true, OnStepX), OnStepX + 1 =< Step) 
-	    then delete(haveDispenserDelivery(true, OnStepX)) + 
+	if percept(step(Step)),
+	   bel(haveDispenserDelivery(true, OnStepX), OnStepX + 1 =< Step)
+	    then delete(haveDispenserDelivery(true, OnStepX)) +
 	         insert(haveDispenserDelivery(false, Step)).
 
 	/**
@@ -166,27 +166,27 @@ module goaldiggerEvent {
 	 */
 
 	% change affinity direction after X steps
-	if bel(changeAffinityAfterTheseSteps(ChangeStep)), 
-	   percept(step(X), X >= 2, 0 =:= mod(X, ChangeStep)), 
-	   bel(randomAffinity(DirOld), randomGoForwardDirection(DirOld, NewDir)) 
-	    then delete (randomAffinity(DirOld)) + 
+	if bel(changeAffinityAfterTheseSteps(ChangeStep)),
+	   percept(step(X), X >= 2, 0 =:= mod(X, ChangeStep)),
+	   bel(randomAffinity(DirOld), randomGoForwardDirection(DirOld, NewDir))
+	    then delete (randomAffinity(DirOld)) +
 	         insert (randomAffinity(NewDir)).
-	    
+
 	% remove switch
-	if bel(calculateNewDispenserMD) 
+	if bel(calculateNewDispenserMD)
 		then delete(calculateNewDispenserMD).
-	if bel(calculateNewGoalzoneMD) 
-		then delete(calculateNewGoalzoneMD).	
-		
+	if bel(calculateNewGoalzoneMD)
+		then delete(calculateNewGoalzoneMD).
+
 	if true then updateMapExploredMarks.
 
 	%If not know goalzone or dispenser, exploreMap
 	if not(bel(executeManhattan)) then updateExploreMoveDirection.
-	
+
 	% SUBMODULE debug with our mini percept
-	if bel(lDebugOn) 
+	if bel(lDebugOn)
 		then logMiniPercept.
-	
+
 	/**
 	 * ACTIVATE MAIN LOOP
 	 *
@@ -194,8 +194,8 @@ module goaldiggerEvent {
 
 
 	% prepare action chosing in main module
-	if bel(haveMove), 
-	   percept(step(SimStep), SimStep >= 0) 
+	if bel(haveMove),
+	   percept(step(SimStep), SimStep >= 0)
 	   	then delete(haveMove).
 
 } % module

--- a/goaldiggersrc/goaldiggerEvent.mod2g
+++ b/goaldiggersrc/goaldiggerEvent.mod2g
@@ -91,14 +91,16 @@ module goaldiggerEvent {
 	% SUBMODULE help test worker tour around the goal zones
 	      
     % remove empty goal zone flag if agent seen in goal zone
-	if bel(customRole(customRoleSaboteur)), percept(team(MyTeam), thing(X, Y, entity, OtherTeam), OtherTeam \= MyTeam, goalZone(X, Y)) then {
+	if bel(customRole(customRoleSaboteur)), bel(whitelistedTeam(MyTeam)), percept(thing(X, Y, entity, OtherTeam), 
+	       OtherTeam \= MyTeam, goalZone(X, Y)) then {
 		forall bel(emptyGoalZoneCounter(A,B,C)) do delete(emptyGoalZoneCounter(A,B,C)).
 	}
     
     %ToDo: Refactor this. WARNING: Changing A and B for some kind of X3, Y3 doesn't work. I don't know why.
 	% set flag if test worker in empty goal zone
-	if bel(customRole(customRoleSaboteur)), percept(goalZone(0, 0)), not(percept(team(MyTeam), thing(X1, Y1, entity, OtherTeam), 
-	       OtherTeam \= MyTeam, goalZone(X1, Y1))), bel(agentAt(X2, Y2, _), minimumDistanceEmptyGoalZone(Distance))
+	if bel(customRole(customRoleSaboteur)), percept(goalZone(0, 0)), bel(whitelistedTeam(MyTeam)), 
+	       not(percept(thing(X1, Y1, entity, OtherTeam), OtherTeam \= MyTeam, goalZone(X1, Y1))), 
+	       bel(agentAt(X2, Y2, _), minimumDistanceEmptyGoalZone(Distance))
 	then {
 	   if bel(emptyGoalZoneCounter(A, B, C), NewCount is C +1, calculateXYMd(A, B, X2, Y2, Md), Md < Distance) then 
 	   delete(emptyGoalZoneCounter(A,B,C)) + insert(emptyGoalZoneCounter(A, B, NewCount)) + 

--- a/goaldiggersrc/goaldiggerInit.mod2g
+++ b/goaldiggersrc/goaldiggerInit.mod2g
@@ -28,8 +28,8 @@ module goaldiggerInit {
 	if true then insert(thisIsTheFirstSim).
 	
 	% variables for saboteur behaviour (againt own team, against other team)
-	if true then insert(sabotageUs).
-	%if true then insert(sabotageThem).
+	%if true then insert(sabotageUs).
+	if true then insert(sabotageThem).
 	
 	% global values
 	% switch to recognize simulations have different characteristics on sim change

--- a/goaldiggersrc/goaldiggerInit.mod2g
+++ b/goaldiggersrc/goaldiggerInit.mod2g
@@ -13,7 +13,7 @@ module goaldiggerInit {
 	% switch to deactivate because not allowed in competition1
 	if true then insert (activateDoubleSpeed). 
 	% switch that activates saboteur in sim
-	%if true then insert (activateSaboteurFeature).
+	if true then insert (activateSaboteurFeature).
 	% To count sim changes
 	if not(bel(simCount(_))) 
 		then insert(simCount(1)). 
@@ -26,6 +26,10 @@ module goaldiggerInit {
 	if not(bel(cachedCount3Task(_))) 
 		then insert(cachedCount3Task(0)). 		
 	if true then insert(thisIsTheFirstSim).
+	
+	% variables for saboteur behaviour (againt own team, against other team)
+	if true then insert(sabotageUs).
+	%if true then insert(sabotageThem).
 	
 	% global values
 	% switch to recognize simulations have different characteristics on sim change

--- a/goaldiggersrc/goaldiggerInit.mod2g
+++ b/goaldiggersrc/goaldiggerInit.mod2g
@@ -28,8 +28,8 @@ module goaldiggerInit {
 	if true then insert(thisIsTheFirstSim).
 	
 	% variables for saboteur behaviour (againt own team, against other team)
-	%if true then insert(sabotageUs).
-	if true then insert(sabotageThem).
+	if true then insert(sabotageUs).
+	%if true then insert(sabotageThem).
 	
 	% global values
 	% switch to recognize simulations have different characteristics on sim change

--- a/goaldiggersrc/goaldiggerProlog.pl
+++ b/goaldiggersrc/goaldiggerProlog.pl
@@ -166,6 +166,9 @@
 :- dynamic sabotageUs/0. % if set, the saboteur sabotages its own team members for testing goals
 :- dynamic sabotageThem/0. % if set, the saboteur sabotages the members of other teams
 :- dynamic whitelistedTeam/1. % holds the name of the team NOT to be sabotaged (us in competition against other teams).
+:- dynamic dragger/0. % flag to drag blokes.
+:- dynamic dragging/0. % flag to signal that blokes are being dragged.
+:- dynamic dragCounter/1. % step counter for dragging actions.
 
 % Transform XY coordinates concerning direction D nswe
 transformXYD(n, X1, Y1, X2, Y2) :- X2 = X1, Y2 is Y1 - 1.

--- a/goaldiggersrc/goaldiggerProlog.pl
+++ b/goaldiggersrc/goaldiggerProlog.pl
@@ -163,6 +163,9 @@
 :- dynamic waitingTimeEmptyGoalZone/1. % Time to wait in an empty goal zone before moving to another one
 :- dynamic tempMapGoalZone/3. % Temporal variable to calculate next goal zone far enough of empty goal zones
 :- dynamic getFree/0. % swicht to detach other bloke
+:- dynamic sabotageUs/0. % if set, the saboteur sabotages its own team members for testing goals
+:- dynamic sabotageThem/0. % if set, the saboteur sabotages the members of other teams
+:- dynamic whitelistedTeam/1. % holds the name of the team NOT to be sabotaged (us in competition against other teams).
 
 % Transform XY coordinates concerning direction D nswe
 transformXYD(n, X1, Y1, X2, Y2) :- X2 = X1, Y2 is Y1 - 1.

--- a/goaldiggersrc/pathfinding/executeMoveAroundBloke.mod2g
+++ b/goaldiggersrc/pathfinding/executeMoveAroundBloke.mod2g
@@ -16,18 +16,18 @@ module executeMoveAroundBloke {
 
 
 	% Bloke attaching if in position
-	if  bel(attachedBlokes(Count), targetBlokeCount(Target), Count < Target),
-	    percept(thing(A, B, entity, _), abs(A) =< 1, abs(B) =< 1),
+	if  bel(attachedBlokes(Count), targetBlokeCount(Target), Count < Target, whitelistedTeam(MyTeam)),
+	    percept(thing(A, B, entity, OtherTeam), MyTeam \= OtherTeam, abs(A) =< 1, abs(B) =< 1),
 	    bel(XPlusY is abs(A) + abs(B), XPlusY \= 0), 
 	    not(percept(attached(A,B))) then {
 	
-		if percept(thing(1, 0, entity,_)), not(percept(attached(1, 0))) 
+		if bel(A =:= 1, B =:= 0), not(percept(attached(1, 0))) 
 		    then preActionCleanup + attach(e).
-		if percept(thing(-1, 0, entity,_)), not(percept(attached(-1, 0))) 
+		if bel(A =:= -1, B =:= 0), not(percept(attached(-1, 0))) 
 		    then preActionCleanup + attach(w).
-		if percept(thing(0, -1, entity,_)), not(percept(attached(0, -1))) 
+		if bel(A =:= 0, B =:= -1), not(percept(attached(0, -1))) 
 		    then preActionCleanup + attach(n).
-		if percept(thing(0, 1, entity,_)), not(percept(attached(0, 1))) 
+		if bel(A =:= 0, B =:= 1), not(percept(attached(0, 1))) 
 		    then preActionCleanup + attach(s).
 	
 	}

--- a/goaldiggersrc/rolehandling/executeSaboteurRole.mod2g
+++ b/goaldiggersrc/rolehandling/executeSaboteurRole.mod2g
@@ -12,7 +12,7 @@ use "../blockhandling/rotateBlockToNorth" as module.
 use "../blockhandling/connectBlocks" as module.
 
 /**
- * Main decision rules for role test worker
+ * Main decision rules for saboteur
  *
  */
 
@@ -37,6 +37,13 @@ module executeSaboteurRole {
 	% detach blocks if they were attached by chance
 	if bel(haveBlockAttached(true, Dir)) 
 	   then detach(Dir).
+	
+	% select sabotage goal
+	if not(bel(whitelistedTeam(_))), bel(sabotageThem), percept(team(MyTeam)) 
+	   then insert(whitelistedTeam(MyTeam)).
+	
+	if not(bel(whitelistedTeam(_))), bel(sabotageUs) 
+	   then insert(whitelistedTeam(fakeTeamName)).
 		
 	%if not(bel(searchInDispenser)) then insert(searchInDispenser).
 
@@ -49,7 +56,8 @@ module executeSaboteurRole {
 	if bel(attachedBlokes(Count), targetBlokeCount(Target), Count < Target) then {	
 	
 		% attach bloke if next to it next to goal zone (without attached blokes)
-		if percept(team(MyTeam), thing(X, Y, entity, OtherTeam), MyTeam \= OtherTeam, abs(X) =< 1, abs(Y) =< 1, goalZone(_,_)), 
+		if bel(whitelistedTeam(MyTeam)), percept(thing(X, Y, entity, OtherTeam), MyTeam \= OtherTeam, abs(X) =< 1, 
+		       abs(Y) =< 1, goalZone(_,_)), 
 		   bel(attachedBlokes(Count), Count == 0), not(percept(attached(X,Y))) then {
 		   % update empty time counter of all dispensers nearby
 		      if bel(searchInDispenser) then {
@@ -63,15 +71,15 @@ module executeSaboteurRole {
 		}
 		
 		% attach bloke anywhere if at least one bloke already attached
-		if percept(team(MyTeam), thing(X, Y, entity, OtherTeam), MyTeam \= OtherTeam, abs(X) =< 1, abs(Y) =< 1), 
+		if bel(whitelistedTeam(MyTeam)), percept(thing(X, Y, entity, OtherTeam), MyTeam \= OtherTeam, abs(X) =< 1, abs(Y) =< 1), 
 		   bel(attachedBlokes(Count), Count > 0), not(percept(attached(X,Y))) then {
 		   % update empty time counter of all dispensers nearby
 		   if true then executeMoveAroundBloke. % attach the bloke
 		}
 		
 		% go to bloke if next to it in goalzone and have 0 or more than 1 blokes
-		if percept(goalZone(_,_)), bel(attachedBlokes(Count), Count \== 1), percept(team(MyTeam), 
-		           thing(X, Y, entity, OtherTeam), MyTeam \= OtherTeam), bel(abs(X) + abs(Y) >= 2) then {
+		if percept(goalZone(_,_)), bel(attachedBlokes(Count), Count \== 1, whitelistedTeam(MyTeam)), 
+		           percept(thing(X, Y, entity, OtherTeam), MyTeam \= OtherTeam), bel(abs(X) + abs(Y) >= 2) then {
 			if bel(X > 0), bel(Y =:= 0), not(percept(attached(1,_))) then move(e).
 			if bel(X < 0), bel(Y =:= 0), not(percept(attached(-1,_))) then move(w).
 			if bel(Y > 0), bel(X =:= 0), not(percept(attached(_,1))) then move(s).
@@ -83,7 +91,7 @@ module executeSaboteurRole {
 		}
 		
 		% go to bloke anywhere if next to it with more than 2 blokes attached
-		if bel(attachedBlokes(Count), Count >= 2), percept(team(MyTeam), thing(X, Y, entity, OtherTeam), 
+		if bel(attachedBlokes(Count), Count >= 2), bel(whitelistedTeam(MyTeam)), percept(thing(X, Y, entity, OtherTeam), 
 		       MyTeam \= OtherTeam), bel(abs(X) + abs(Y) >= 2) then {
 			if bel(X > 0), bel(Y =:= 0), not(percept(attached(1,_))) then move(e).
 			if bel(X < 0), bel(Y =:= 0), not(percept(attached(-1,_))) then move(w).

--- a/goaldiggersrc/rolehandling/executeSaboteurRole.mod2g
+++ b/goaldiggersrc/rolehandling/executeSaboteurRole.mod2g
@@ -104,19 +104,24 @@ module executeSaboteurRole {
 		}
 
 
+
+		% roam goal zone if still not declared empty
+		if percept(goalZone(0,0)), bel(whitelistedTeam(MyTeam)), not(percept(thing(X1,Y1,entity,OtherTeam), 
+		   goalZone(X1,Y1), OtherTeam \= MyTeam)), not(bel(X1 \= 0, Y1 \= 0)), bel(agentAt(X4, Y4, _)), 
+		   not(bel(minimumDistanceEmptyGoalZone(Distance), waitingTimeEmptyGoalZone(Time), emptyGoalZoneCounter(X5, Y5, C), 
+		   calculateXYMd(X5, Y5, X4, Y4, Md), Md < Distance, C > Time)) then {
+		     
+		     forall bel(randomDirection(Dir), directionToCoordinate(Dir, X2, Y2)), percept(goalZone(X2, Y2)) do {
+		     		if percept(thing(X2, Y2, block, _)) then clear(X2, Y2).
+		     		if not(percept(thing(X2, Y2, block, _))) then move(Dir).
+		     }		        
+		}
+		
+
 		% go to a goal zone if no bloke attached
 		if bel(attachedBlokes(Count), Count == 0), bel(targetMd(_, _, goalzone), executeManhattan)
 		then executeManhattanMove.
-		
-		% roam goal zone
-		if percept(goalZone(0,0), goalZone(X1, Y1)), not(bel(X1 \= 0, Y1 \= 0)), bel(agentAt(X,Y,_)), 
-		   bel(emptyGoalZoneCounter(A, B, _),  minimumDistanceEmptyGoalZone(Distance), calculateXYMd(A, B, X, Y, Md), 
-		   Md < Distance) then {	   			
-			if bel(X1 > 0), bel(Y1 \= 0) then move(e).
-			if bel(X1 < 0), bel(Y1 \= 0) then move(w).
-			if bel(Y1 > 0), bel(X1 \= 0) then move(s).
-			if bel(Y1 < 0), bel(X1 \= 0) then move(n).
-		}
+
 		% roam if no distant goal zone available
 		if bel(emptyGoalZoneCounter(_,_,Count), waitingTimeEmptyGoalZone(Time), Count > Time, attachedBlokes(Count), 
 		       Count == 0)

--- a/goaldiggersrc/rolehandling/executeSaboteurRole.mod2g
+++ b/goaldiggersrc/rolehandling/executeSaboteurRole.mod2g
@@ -10,6 +10,7 @@ use "../taskhandling/handleTaskSubmit" as module.
 use "../blockhandling/rotateBlockAgainstAffinity" as module.
 use "../blockhandling/rotateBlockToNorth" as module.
 use "../blockhandling/connectBlocks" as module.
+use "../blockhandling/detachBloke" as module.
 
 /**
  * Main decision rules for saboteur
@@ -44,8 +45,13 @@ module executeSaboteurRole {
 	
 	if not(bel(whitelistedTeam(_))), bel(sabotageUs) 
 	   then insert(whitelistedTeam(fakeTeamName)).
+
+	% drag single blokes
+	if not(bel(dragger)) then insert(dragger).
 		
 	%if not(bel(searchInDispenser)) then insert(searchInDispenser).
+
+
 
     /**
 	 * WITHOUT BLOKE	
@@ -54,10 +60,23 @@ module executeSaboteurRole {
 	
 	
 	if bel(attachedBlokes(Count), targetBlokeCount(Target), Count < Target) then {	
+
+
+		% stop dragging single blokes
+		if bel(dragging, dragCounter(Count), Count >= 20), not(percept(goalZone(_,_)))
+		   then delete(dragging) + delete(dragCounter(Count)) + allother.send(mensaje("Detached bloke")) + detachBloke.
+
+		% drag single blokes	
+		if bel(dragger, attachedBlokes(Count), Count =:= 1)
+		   then {
+		     if not(bel(dragging)) then insert(dragging) + insert(dragCounter(0)).
+		     if true then executeRandomMove.
+		}
+		   
 	
-		% attach bloke if next to it on goal zone (without attached blokes)
+		% attach bloke if next to it next to goal zone (without attached blokes)
 		if bel(whitelistedTeam(MyTeam)), percept(thing(X, Y, entity, OtherTeam), MyTeam \= OtherTeam, abs(X) =< 1, 
-		       abs(Y) =< 1, goalZone(X,Y)), 
+		       abs(Y) =< 1, goalZone(_,_)), 
 		   bel(attachedBlokes(Count), Count == 0), not(percept(attached(X,Y))) then {
 		   % update empty time counter of all dispensers nearby
 		      if bel(searchInDispenser) then {

--- a/goaldiggersrc/rolehandling/executeSaboteurRole.mod2g
+++ b/goaldiggersrc/rolehandling/executeSaboteurRole.mod2g
@@ -73,18 +73,16 @@ module executeSaboteurRole {
 		     if true then executeRandomMove.
 		}
 
-		% go to bloke anywhere if dragger without blokes attached
-		if bel(dragger, attachedBlokes(Count), Count =:= 0, targetMd(_, _, agent), executeManhattan)
-		then executeManhattanMove.
-		
 		% attach blokes anywhere if dragger 
 		if bel(dragger, attachedBlokes(Count), Count =:= 0, whitelistedTeam(MyTeam)), 
 		   percept(thing(X, Y, entity, OtherTeam), MyTeam \= OtherTeam, abs(X) =< 1, abs(Y) =< 1),
 		   not(bel(X =:= 0, Y =:= 0)), not(percept(attached(X,Y)))
 		    then executeMoveAroundBloke.
-	
 
-	
+		% go to bloke anywhere if dragger without blokes attached
+		if bel(dragger, attachedBlokes(Count), Count =:= 0, targetMd(_, _, agent), executeManhattan)
+		then allother.send(executingManhattan("Following someone!")) + executeManhattanMove.
+		
 	
 		% attach bloke if next to it next to goal zone (without attached blokes)
 		if bel(whitelistedTeam(MyTeam)), percept(thing(X, Y, entity, OtherTeam), MyTeam \= OtherTeam, abs(X) =< 1, 

--- a/goaldiggersrc/rolehandling/executeSaboteurRole.mod2g
+++ b/goaldiggersrc/rolehandling/executeSaboteurRole.mod2g
@@ -47,7 +47,7 @@ module executeSaboteurRole {
 	   then insert(whitelistedTeam(fakeTeamName)).
 
 	% drag single blokes
-	if not(bel(dragger)) then insert(dragger).
+	%if not(bel(dragger)) then insert(dragger).
 		
 	%if not(bel(searchInDispenser)) then insert(searchInDispenser).
 
@@ -118,8 +118,8 @@ module executeSaboteurRole {
 		   calculateXYMd(X5, Y5, X4, Y4, Md), Md < Distance, C > Time)) then {
 		     
 		     forall bel(randomDirection(Dir), directionToCoordinate(Dir, X2, Y2)), percept(goalZone(X2, Y2)) do {
-		     		if percept(thing(X2, Y2, block, _)) then clear(X2, Y2).
-		     		if not(percept(thing(X2, Y2, block, _))) then move(Dir).
+		     		if percept(thing(X2, Y2, obstacle, _)) then clear(X2, Y2).
+		     		if not(percept(thing(X2, Y2, obstacle, _))) then move(Dir).
 		     }		        
 		}
 
@@ -133,7 +133,7 @@ module executeSaboteurRole {
 		   then executeRandomMove.
 
 		% clear blocks when in goal zone
-		if percept(goalZone(0,0), thing(X, Y, block, _), abs(X) =< 1, abs(Y) =< 1) 
+		if percept(goalZone(0,0), thing(X, Y, obstacle, _), abs(X) + abs(Y) =:= 1) 
 		   then clear(X,Y).				
 
 
@@ -171,6 +171,7 @@ module executeSaboteurRole {
 		if bel(attachedBlokes(Count), Count == 0) then executeRandomMove.
 		
 		if bel(dragger) then executeRandomMove.
+		if percept(thing(X,Y,obstacle,_), abs(X) + abs(Y) =:= 1) then clear(X,Y).
 		if true then skip.
 	
 	

--- a/goaldiggersrc/rolehandling/executeSaboteurRole.mod2g
+++ b/goaldiggersrc/rolehandling/executeSaboteurRole.mod2g
@@ -47,7 +47,7 @@ module executeSaboteurRole {
 	   then insert(whitelistedTeam(fakeTeamName)).
 
 	% drag single blokes
-	%if not(bel(dragger)) then insert(dragger).
+	if not(bel(dragger)) then insert(dragger).
 		
 	%if not(bel(searchInDispenser)) then insert(searchInDispenser).
 
@@ -112,16 +112,16 @@ module executeSaboteurRole {
 
 		% roam goal zone if still not declared empty
 		if percept(goalZone(0,0)), bel(whitelistedTeam(MyTeam)), 
-		   not(percept(thing(X1,Y1,entity,OtherTeam), goalZone(X1,Y1), OtherTeam \= MyTeam)), 
-		   not(bel(X1 \= 0, Y1 \= 0)), not(percept(attached(X1, Y1))), bel(agentAt(X4, Y4, _)), 
+		   not(percept(thing(X1,Y1,entity,OtherTeam), goalZone(X1,Y1), OtherTeam \= MyTeam, (X1 \= 0; Y1 \= 0))), 
+		   not(percept(attached(X1, Y1))), bel(agentAt(X4, Y4, _)), 
 		   not(bel(minimumDistanceEmptyGoalZone(Distance), waitingTimeEmptyGoalZone(Time), emptyGoalZoneCounter(X5, Y5, C), 
-		   calculateXYMd(X5, Y5, X4, Y4, Md), Md < Distance, C > Time)) then {
+		   calculateXYMd(X5, Y5, X4, Y4, Md), Md < Distance, C > Time)) then executeManhattanMove. %{
 		     
-		     forall bel(randomDirection(Dir), directionToCoordinate(Dir, X2, Y2)), percept(goalZone(X2, Y2)) do {
-		     		if percept(thing(X2, Y2, obstacle, _)) then clear(X2, Y2).
-		     		if not(percept(thing(X2, Y2, obstacle, _))) then move(Dir).
-		     }		        
-		}
+		     %forall bel(randomDirection(Dir), directionToCoordinate(Dir, X2, Y2)), percept(goalZone(X2, Y2)) do {
+		     %		if percept(thing(X2, Y2, obstacle, _)) then clear(X2, Y2).
+		     % 		if not(percept(thing(X2, Y2, obstacle, _))) then move(Dir).
+		     %}		        
+		%}
 
 		if bel(attachedBlokes(Count), Count == 0), bel(targetMd(_, _, goalzone), executeManhattan)
 		then executeManhattanMove.
@@ -137,41 +137,13 @@ module executeSaboteurRole {
 		   then clear(X,Y).				
 
 
-
-        % go to a goal zone if next to it
-		%if not(percept(goalZone(0,0))), percept(goalZone(X, Y)) then {
-		%   	if bel(X > 0), bel(Y \= 0) then move(e).
-		%	if bel(X < 0), bel(Y \= 0) then move(w).
-		%	if bel(Y > 0), bel(X \= 0) then move(s).
-		%	if bel(Y < 0), bel(X \= 0) then move(n).
-		%}
-
-		% if no free agent around, go to a goal zone
-		% if not(percept(thing(X, Y, entity, _))), bel(X \= 0; Y \=0), not(percept(attached(X, Y))), 
-		%   not(percept(goalZone(_,_))), bel(targetMd(_, _, goalzone), executeManhattan) 
-		%then all.send(goToGoal("Go to goal zone")) + executeManhattanMove.
-		
-		% if no agent around, go to a dispenser
-		%if not(percept(thing(X, Y, entity, _))), bel(X \= 0; Y \=0), not(percept(attached(X, Y))), 
-		%   not(percept(thing(_,_,dispenser,_))), bel(targetMd(_, _, dispenser), executeManhattan) 
-		%then executeManhattanMove. 
-
-		% if at a dispenser and no agents around, count steps without seeing agents around
-		%if percept(thing(X0, Y0, dispenser, _)), not(percept(thing(X1, Y1, entity, _), X1 \= 0, Y1 \= 0)),
-		%   bel(agentAt(X2, Y2, _), localize(X0, Y0, X2, Y2, X3, Y3))
-		%then {
-		%   if bel(emptyDispenserCounter(X3, Y3, Count), NewCount is Count + 1)
-		%   then delete(emptyDispenserCounter(X3, Y3, Count)) + insert(emptyDispenserCounter(X3, Y3, NewCount)).
-		%   if not(bel(emptyDispenserCounter(X3, Y3, _))) then insert(emptyDispenserCounter(X3, Y3, 1)).
-		%}
-			
-		
-		%if percept(goalZone(0,0), bel(attachedBlokes(Count), Count \== 1)) then executeRandomMove.
 		
 		if bel(attachedBlokes(Count), Count == 0) then executeRandomMove.
 		
 		if bel(dragger) then executeRandomMove.
+
 		if percept(thing(X,Y,obstacle,_), abs(X) + abs(Y) =:= 1) then clear(X,Y).
+
 		if true then skip.
 	
 	

--- a/goaldiggersrc/rolehandling/executeSaboteurRole.mod2g
+++ b/goaldiggersrc/rolehandling/executeSaboteurRole.mod2g
@@ -47,7 +47,7 @@ module executeSaboteurRole {
 	   then insert(whitelistedTeam(fakeTeamName)).
 
 	% drag single blokes
-	if not(bel(dragger)) then insert(dragger).
+	%if not(bel(dragger)) then insert(dragger).
 		
 	%if not(bel(searchInDispenser)) then insert(searchInDispenser).
 
@@ -72,7 +72,28 @@ module executeSaboteurRole {
 		     if not(bel(dragging)) then insert(dragging) + insert(dragCounter(0)).
 		     if true then executeRandomMove.
 		}
-		   
+
+		% go to bloke anywhere if dragger without blokes attached
+		if bel(dragger, attachedBlokes(Count), Count =:= 0), bel(whitelistedTeam(MyTeam)), percept(thing(X, Y, entity, OtherTeam), 
+		       MyTeam \= OtherTeam), not(percept(attached(X,Y))), bel(abs(X) + abs(Y) >= 2) then {
+			if bel(X > 0), bel(Y =:= 0), not(percept(attached(1,_))) then move(e).
+			if bel(X < 0), bel(Y =:= 0), not(percept(attached(-1,_))) then move(w).
+			if bel(Y > 0), bel(X =:= 0), not(percept(attached(_,1))) then move(s).
+			if bel(Y < 0), bel(X =:= 0), not(percept(attached(_,-1))) then move(n).
+			if bel(X > 0), bel(Y \= 0) then move(e).
+			if bel(X < 0), bel(Y \= 0) then move(w).
+			if bel(Y > 0), bel(X \= 0) then move(s).
+			if bel(Y < 0), bel(X \= 0) then move(n).
+		}
+		
+		% attach blokes anywhere if dragger 
+		if bel(dragger, attachedBlokes(Count), Count =:= 0, whitelistedTeam(MyTeam)), 
+		   percept(thing(X, Y, entity, OtherTeam), MyTeam \= OtherTeam, abs(X) =< 1, abs(Y) =< 1),
+		   not(bel(X =:= 0, Y =:= 0)), not(percept(attached(X,Y)))
+		    then executeMoveAroundBloke.
+	
+
+	
 	
 		% attach bloke if next to it next to goal zone (without attached blokes)
 		if bel(whitelistedTeam(MyTeam)), percept(thing(X, Y, entity, OtherTeam), MyTeam \= OtherTeam, abs(X) =< 1, 
@@ -148,8 +169,8 @@ module executeSaboteurRole {
 		       Count == 0)
 		   then executeRandomMove.
 
-		% clear blocks when next to goal zone
-		if percept(goalZone(_,_), thing(X, Y, block, _), abs(X) =< 1, abs(Y) =< 1) 
+		% clear blocks when in goal zone
+		if percept(goalZone(0,0), thing(X, Y, block, _), abs(X) =< 1, abs(Y) =< 1) 
 		   then clear(X,Y).				
 
 
@@ -186,6 +207,7 @@ module executeSaboteurRole {
 		
 		if bel(attachedBlokes(Count), Count == 0) then executeRandomMove.
 		
+		if bel(dragger) then executeRandomMove.
 		if true then skip.
 	
 	

--- a/goaldiggersrc/rolehandling/executeSaboteurRole.mod2g
+++ b/goaldiggersrc/rolehandling/executeSaboteurRole.mod2g
@@ -32,7 +32,7 @@ module executeSaboteurRole {
 	
 	% insert waiting time in empty goal zone
 	if not(bel(waitingTimeEmptyGoalZone(_)))
-	   then insert(waitingTimeEmptyGoalZone(15)).	
+	   then insert(waitingTimeEmptyGoalZone(10)).	
 	
 	% detach blocks if they were attached by chance
 	if bel(haveBlockAttached(true, Dir)) 
@@ -108,6 +108,15 @@ module executeSaboteurRole {
 		if bel(attachedBlokes(Count), Count == 0), bel(targetMd(_, _, goalzone), executeManhattan)
 		then executeManhattanMove.
 		
+		% roam goal zone
+		if percept(goalZone(0,0), goalZone(X1, Y1)), not(bel(X1 \= 0, Y1 \= 0)), bel(agentAt(X,Y,_)), 
+		   bel(emptyGoalZoneCounter(A, B, _),  minimumDistanceEmptyGoalZone(Distance), calculateXYMd(A, B, X, Y, Md), 
+		   Md < Distance) then {	   			
+			if bel(X1 > 0), bel(Y1 \= 0) then move(e).
+			if bel(X1 < 0), bel(Y1 \= 0) then move(w).
+			if bel(Y1 > 0), bel(X1 \= 0) then move(s).
+			if bel(Y1 < 0), bel(X1 \= 0) then move(n).
+		}
 		% roam if no distant goal zone available
 		if bel(emptyGoalZoneCounter(_,_,Count), waitingTimeEmptyGoalZone(Time), Count > Time, attachedBlokes(Count), 
 		       Count == 0)

--- a/goaldiggersrc/rolehandling/executeSaboteurRole.mod2g
+++ b/goaldiggersrc/rolehandling/executeSaboteurRole.mod2g
@@ -55,9 +55,9 @@ module executeSaboteurRole {
 	
 	if bel(attachedBlokes(Count), targetBlokeCount(Target), Count < Target) then {	
 	
-		% attach bloke if next to it next to goal zone (without attached blokes)
+		% attach bloke if next to it on goal zone (without attached blokes)
 		if bel(whitelistedTeam(MyTeam)), percept(thing(X, Y, entity, OtherTeam), MyTeam \= OtherTeam, abs(X) =< 1, 
-		       abs(Y) =< 1, goalZone(_,_)), 
+		       abs(Y) =< 1, goalZone(X,Y)), 
 		   bel(attachedBlokes(Count), Count == 0), not(percept(attached(X,Y))) then {
 		   % update empty time counter of all dispensers nearby
 		      if bel(searchInDispenser) then {
@@ -79,7 +79,8 @@ module executeSaboteurRole {
 		
 		% go to bloke if next to it in goalzone and have 0 or more than 1 blokes
 		if percept(goalZone(_,_)), bel(attachedBlokes(Count), Count \== 1, whitelistedTeam(MyTeam)), 
-		           percept(thing(X, Y, entity, OtherTeam), MyTeam \= OtherTeam), bel(abs(X) + abs(Y) >= 2) then {
+		           percept(thing(X, Y, entity, OtherTeam), MyTeam \= OtherTeam), not(percept(attached(X,Y))),
+		           bel(abs(X) + abs(Y) >= 2) then {
 			if bel(X > 0), bel(Y =:= 0), not(percept(attached(1,_))) then move(e).
 			if bel(X < 0), bel(Y =:= 0), not(percept(attached(-1,_))) then move(w).
 			if bel(Y > 0), bel(X =:= 0), not(percept(attached(_,1))) then move(s).
@@ -92,7 +93,7 @@ module executeSaboteurRole {
 		
 		% go to bloke anywhere if next to it with more than 2 blokes attached
 		if bel(attachedBlokes(Count), Count >= 2), bel(whitelistedTeam(MyTeam)), percept(thing(X, Y, entity, OtherTeam), 
-		       MyTeam \= OtherTeam), bel(abs(X) + abs(Y) >= 2) then {
+		       MyTeam \= OtherTeam), not(percept(attached(X,Y))), bel(abs(X) + abs(Y) >= 2) then {
 			if bel(X > 0), bel(Y =:= 0), not(percept(attached(1,_))) then move(e).
 			if bel(X < 0), bel(Y =:= 0), not(percept(attached(-1,_))) then move(w).
 			if bel(Y > 0), bel(X =:= 0), not(percept(attached(_,1))) then move(s).
@@ -106,8 +107,9 @@ module executeSaboteurRole {
 
 
 		% roam goal zone if still not declared empty
-		if percept(goalZone(0,0)), bel(whitelistedTeam(MyTeam)), not(percept(thing(X1,Y1,entity,OtherTeam), 
-		   goalZone(X1,Y1), OtherTeam \= MyTeam)), not(bel(X1 \= 0, Y1 \= 0)), bel(agentAt(X4, Y4, _)), 
+		if percept(goalZone(0,0)), bel(whitelistedTeam(MyTeam)), 
+		   not(percept(thing(X1,Y1,entity,OtherTeam), goalZone(X1,Y1), OtherTeam \= MyTeam)), 
+		   not(bel(X1 \= 0, Y1 \= 0)), not(percept(attached(X1, Y1))), bel(agentAt(X4, Y4, _)), 
 		   not(bel(minimumDistanceEmptyGoalZone(Distance), waitingTimeEmptyGoalZone(Time), emptyGoalZoneCounter(X5, Y5, C), 
 		   calculateXYMd(X5, Y5, X4, Y4, Md), Md < Distance, C > Time)) then {
 		     
@@ -161,7 +163,7 @@ module executeSaboteurRole {
 		%}
 			
 		
-		if percept(goalZone(0,0), bel(attachedBlokes(Count), Count \== 1)) then executeRandomMove.
+		%if percept(goalZone(0,0), bel(attachedBlokes(Count), Count \== 1)) then executeRandomMove.
 		
 		if bel(attachedBlokes(Count), Count == 0) then executeRandomMove.
 		

--- a/goaldiggersrc/rolehandling/executeSaboteurRole.mod2g
+++ b/goaldiggersrc/rolehandling/executeSaboteurRole.mod2g
@@ -97,7 +97,7 @@ module executeSaboteurRole {
 	
 		% attach bloke if next to it next to goal zone (without attached blokes)
 		if bel(whitelistedTeam(MyTeam)), percept(thing(X, Y, entity, OtherTeam), MyTeam \= OtherTeam, abs(X) =< 1, 
-		       abs(Y) =< 1, goalZone(_,_)), 
+		       abs(Y) =< 1, goalZone(_,_)), not(bel(X =:= 0, Y =:= 0)), 
 		   bel(attachedBlokes(Count), Count == 0), not(percept(attached(X,Y))) then {
 		   % update empty time counter of all dispensers nearby
 		      if bel(searchInDispenser) then {

--- a/goaldiggersrc/rolehandling/executeSaboteurRole.mod2g
+++ b/goaldiggersrc/rolehandling/executeSaboteurRole.mod2g
@@ -63,8 +63,8 @@ module executeSaboteurRole {
 
 
 		% stop dragging single blokes
-		if bel(dragging, dragCounter(Count), Count >= 20), not(percept(goalZone(_,_)))
-		   then delete(dragging) + delete(dragCounter(Count)) + allother.send(mensaje("Detached bloke")) + detachBloke.
+		if bel(dragging, dragCounter(DragCount), DragCount > 5), not(percept(goalZone(_,_)))
+		   then delete(dragging) + delete(dragCounter(DragCount)) + detachBloke.
 
 		% drag single blokes	
 		if bel(dragger, attachedBlokes(Count), Count =:= 1)

--- a/goaldiggersrc/rolehandling/executeSaboteurRole.mod2g
+++ b/goaldiggersrc/rolehandling/executeSaboteurRole.mod2g
@@ -47,7 +47,7 @@ module executeSaboteurRole {
 	   then insert(whitelistedTeam(fakeTeamName)).
 
 	% drag single blokes
-	%if not(bel(dragger)) then insert(dragger).
+	if not(bel(dragger)) then insert(dragger).
 		
 	%if not(bel(searchInDispenser)) then insert(searchInDispenser).
 
@@ -74,17 +74,8 @@ module executeSaboteurRole {
 		}
 
 		% go to bloke anywhere if dragger without blokes attached
-		if bel(dragger, attachedBlokes(Count), Count =:= 0), bel(whitelistedTeam(MyTeam)), percept(thing(X, Y, entity, OtherTeam), 
-		       MyTeam \= OtherTeam), not(percept(attached(X,Y))), bel(abs(X) + abs(Y) >= 2) then {
-			if bel(X > 0), bel(Y =:= 0), not(percept(attached(1,_))) then move(e).
-			if bel(X < 0), bel(Y =:= 0), not(percept(attached(-1,_))) then move(w).
-			if bel(Y > 0), bel(X =:= 0), not(percept(attached(_,1))) then move(s).
-			if bel(Y < 0), bel(X =:= 0), not(percept(attached(_,-1))) then move(n).
-			if bel(X > 0), bel(Y \= 0) then move(e).
-			if bel(X < 0), bel(Y \= 0) then move(w).
-			if bel(Y > 0), bel(X \= 0) then move(s).
-			if bel(Y < 0), bel(X \= 0) then move(n).
-		}
+		if bel(dragger, attachedBlokes(Count), Count =:= 0, targetMd(_, _, agent), executeManhattan)
+		then executeManhattanMove.
 		
 		% attach blokes anywhere if dragger 
 		if bel(dragger, attachedBlokes(Count), Count =:= 0, whitelistedTeam(MyTeam)), 
@@ -116,35 +107,10 @@ module executeSaboteurRole {
 		   % update empty time counter of all dispensers nearby
 		   if true then executeMoveAroundBloke. % attach the bloke
 		}
-		
-		% go to bloke if next to it in goalzone and have 0 or more than 1 blokes
-		if percept(goalZone(_,_)), bel(attachedBlokes(Count), Count \== 1, whitelistedTeam(MyTeam)), 
-		           percept(thing(X, Y, entity, OtherTeam), MyTeam \= OtherTeam), not(percept(attached(X,Y))),
-		           bel(abs(X) + abs(Y) >= 2) then {
-			if bel(X > 0), bel(Y =:= 0), not(percept(attached(1,_))) then move(e).
-			if bel(X < 0), bel(Y =:= 0), not(percept(attached(-1,_))) then move(w).
-			if bel(Y > 0), bel(X =:= 0), not(percept(attached(_,1))) then move(s).
-			if bel(Y < 0), bel(X =:= 0), not(percept(attached(_,-1))) then move(n).
-			if bel(X > 0), bel(Y \= 0) then move(e).
-			if bel(X < 0), bel(Y \= 0) then move(w).
-			if bel(Y > 0), bel(X \= 0) then move(s).
-			if bel(Y < 0), bel(X \= 0) then move(n).
-		}
-		
-		% go to bloke anywhere if next to it with more than 2 blokes attached
-		if bel(attachedBlokes(Count), Count >= 2), bel(whitelistedTeam(MyTeam)), percept(thing(X, Y, entity, OtherTeam), 
-		       MyTeam \= OtherTeam), not(percept(attached(X,Y))), bel(abs(X) + abs(Y) >= 2) then {
-			if bel(X > 0), bel(Y =:= 0), not(percept(attached(1,_))) then move(e).
-			if bel(X < 0), bel(Y =:= 0), not(percept(attached(-1,_))) then move(w).
-			if bel(Y > 0), bel(X =:= 0), not(percept(attached(_,1))) then move(s).
-			if bel(Y < 0), bel(X =:= 0), not(percept(attached(_,-1))) then move(n).
-			if bel(X > 0), bel(Y \= 0) then move(e).
-			if bel(X < 0), bel(Y \= 0) then move(w).
-			if bel(Y > 0), bel(X \= 0) then move(s).
-			if bel(Y < 0), bel(X \= 0) then move(n).
-		}
 
 
+		if bel(targetMd(_, _, agent), executeManhattan)
+		then executeManhattanMove.
 
 		% roam goal zone if still not declared empty
 		if percept(goalZone(0,0)), bel(whitelistedTeam(MyTeam)), 
@@ -158,11 +124,10 @@ module executeSaboteurRole {
 		     		if not(percept(thing(X2, Y2, block, _))) then move(Dir).
 		     }		        
 		}
-		
 
-		% go to a goal zone if no bloke attached
 		if bel(attachedBlokes(Count), Count == 0), bel(targetMd(_, _, goalzone), executeManhattan)
 		then executeManhattanMove.
+				
 
 		% roam if no distant goal zone available
 		if bel(emptyGoalZoneCounter(_,_,Count), waitingTimeEmptyGoalZone(Time), Count > Time, attachedBlokes(Count), 


### PR DESCRIPTION
We have added new features to the saboteur custom role:
- Roaming goal zones until declared empty if no enemy entity can be seen
- Touring different goal zones if they are not being visited by enemy entities
- Dragging function: attached entities are dragged for some time in some direction to alter their coordinate systems
- Target entities are pursued effectively

Unfortunately we have discovered that only friendly entities can be attached. Enemy entity attachment fails with a failed_target error.